### PR TITLE
Allow concurrency in checks

### DIFF
--- a/doc/user/configuration.rst
+++ b/doc/user/configuration.rst
@@ -61,6 +61,12 @@ All these parameters can be left out, in this case they take their default value
     A path containing other configuration files to include. It can be used to separate each plugin
     in its own configuration file. File globs are expanded, example ``/etc/sauna.d/*.yml``.
 
+**concurrency**
+    How many threads can process the checks at the same time. The default value of 1 means sauna will
+    run checks one by one.
+    Note that activating the concurrency system will, by default, only allow 1 check with the same name to run at the
+    same time.
+
 Example::
 
     ---

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -244,3 +244,26 @@ class ConfigTest(unittest.TestCase):
         generated_yaml_string = f.write.call_args[0][0]
         # Will raise a yaml error if generated content is not valid yaml
         yaml.safe_load(generated_yaml_string)
+
+    def test_conf_with_concurrency_instantiates_threadpool(self):
+        original = {
+            'periodicity': 60,
+            'concurrency': 5,
+            'consumers': {
+                'Stdout': {}
+            },
+            'plugins': []
+        }
+        sauna = Sauna(config=original)
+        self.assertIsNotNone(sauna._thread_pool)
+
+    def test_conf_without_concurrency_no_threadpool(self):
+        original = {
+            'periodicity': 60,
+            'consumers': {
+                'Stdout': {},
+            },
+            'plugins': []
+        }
+        sauna = Sauna(config=original)
+        self.assertIsNone(sauna._thread_pool)


### PR DESCRIPTION
Features:

- concurrency parameter: if provided and greater than 1, you can run multiple checks concurrently (defaults to 1, default behavior).

This may be a specific use case, but useful for a lot of people. Indeed, when running a huge amount of checks, that sometime can take seconds to process, we sometimes go from 1 check per minute (depend on my configuration) to 1 check every 3 minute (because of some checks taking too much time)