### PR TITLE
 Fixe the uid of user sauna when creating it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Nicolas Le Manchet <nicolas@lemanchet.fr>
 
 RUN set -x \
     && addgroup -S sauna \
-    && adduser -D -S -h /app -G sauna sauna \
+    && adduser -u 4343 -D -S -h /app -G sauna sauna \
     && apk update \
     && apk add python3 py3-psutil py3-yaml py3-docopt py3-requests \
     && pip3 install redis pymdstat jsonpath-rw

--- a/doc/user/install.rst
+++ b/doc/user/install.rst
@@ -15,7 +15,7 @@ Pip
 If you are familiar with the Python ecosystem, you won't be surprised that sauna can be installed
 with::
 
-    $ pip install sauna 
+    $ pip install sauna
 
 That's it, you can call it a day!
 
@@ -57,4 +57,9 @@ allows to run sauna in a container::
 
     $ docker pull nicolaslm/sauna
 
+If you want to share the configuration between the host and the container using a volume, be carreful about file permissions.
 
+The configuration file might contains some sensible data like password and should not be readable for everyone. But inside the container sauna runs as user *sauna* (uid 4343) and need to read the configuration file.
+To do so, the easiest way is to create a user on the host with the same uid (4343) and chown the configuration file with this user. Then you can mount the configuration file inside the container and run sauna with ::
+
+    $ docker run -v /etc/sauna.yml:/app/sauna.yml:ro nicolaslm/sauna


### PR DESCRIPTION
 It ease the use of the docker container : without it you need to allow
 everyone to read the configuration file on the host, mount it in the
 container with a volume to allow sauna user inside the container to read
 it.

 With this patch, you only need to create a user with uid 4343 on the
 host, chown the configuration file with this host and proceed.