### PR TITLE
Improve network plugin execution time

### DIFF
--- a/sauna/plugins/ext/network.py
+++ b/sauna/plugins/ext/network.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 import time
 
 from sauna.plugins.base import PsutilPlugin
@@ -53,6 +54,7 @@ class Network(PsutilPlugin):
             'Download : {} p/s'.format(dl)
         )
 
+    @lru_cache()
     def get_network_data(self, interface='eth0', delay=1):
         t0 = time.time()
         counter = self.psutil.net_io_counters(pernic=True)[interface]


### PR DESCRIPTION
When having the 4 networks checks (data up/down and packets up/down) on
an interface, Sauna used to execute them sequentially. It now executes
it once and cache the result for the other checks of the same interface.

It means that instead of taking 4 seconds to execute, they now only take
1 second.