### PR TITLE
Changing exit() to sys.exit()

### DIFF
--- a/sauna/__init__.py
+++ b/sauna/__init__.py
@@ -87,7 +87,7 @@ def read_config(config_file):
     except OSError as e:
         print('Cannot read configuration file {}: {}'
               .format(config_file, e))
-        exit(1)
+        sys.exit(1)
 
     for config_file_included in glob.glob(config.get('include', '')):
         config_included = read_config(config_file_included)
@@ -170,7 +170,7 @@ class Sauna:
             plugins = self.config['plugins']
         else:
             print('Invalid configuration, plugins must be a list or a dict')
-            exit(1)
+            sys.exit(1)
         return plugins
 
     @property
@@ -187,7 +187,7 @@ class Sauna:
             consumers = self.config['consumers']
         else:
             print('Invalid configuration, consumers must be a list or a dict')
-            exit(1)
+            sys.exit(1)
         return consumers
 
     def get_active_checks_name(self):
@@ -218,7 +218,7 @@ class Sauna:
             plugin_info = PluginRegister.get_plugin(plugin_name)
             if not plugin_info:
                 print('Plugin {} does not exist'.format(plugin_name))
-                exit(1)
+                sys.exit(1)
 
             # Configure plugin
             try:
@@ -235,7 +235,7 @@ class Sauna:
                 if func_name is None:
                     print('Unknown check {} on plugin {}'.format(check['type'],
                                                                  plugin_name))
-                    exit(1)
+                    sys.exit(1)
                 check_func = getattr(plugin, func_name)
 
                 # An empty string is a valid check name
@@ -252,7 +252,7 @@ class Sauna:
         if deps_error:
             for error in deps_error:
                 print(error)
-            exit(1)
+            sys.exit(1)
 
         # Check duplicate name
         names = [check.name for check in checks]
@@ -262,7 +262,7 @@ class Sauna:
             print("check name {} was found {} times, please add name"
                   " field to theses checks".format(name, count))
         if duplicates_names:
-            exit(1)
+            sys.exit(1)
         return checks
 
     def launch_all_checks(self):
@@ -364,14 +364,14 @@ class Sauna:
             consumer_info = ConsumerRegister.get_consumer(consumer_name)
             if not consumer_info:
                 print('Plugin {} does not exist'.format(consumer_name))
-                exit(1)
+                sys.exit(1)
 
             try:
                 consumer = consumer_info['consumer_cls'](consumer_data)
             except DependencyError as e:
                 print(str(e))
                 self.term_handler()
-                exit(1)
+                sys.exit(1)
 
             if isinstance(consumer, QueuedConsumer):
                 consumer_queue = queue.Queue()

--- a/sauna/main.py
+++ b/sauna/main.py
@@ -17,6 +17,7 @@ Options:
 
 Available commands:
 """
+import sys
 import logging
 import logging.config
 
@@ -51,14 +52,14 @@ def main():
         sauna_instance = sauna.Sauna()
         file_path = sauna_instance.assemble_config_sample('./')
         print('Created file {}'.format(file_path))
-        exit(0)
+        sys.exit(0)
 
     try:
         config = sauna.read_config(conf_file)
     except YAMLError as e:
         print('YAML syntax in configuration file {} is not valid: {}'.
               format(conf_file, e))
-        exit(1)
+        sys.exit(1)
 
     if 'logging' in config:
         # Override the logging configuration with the one from the config file
@@ -73,7 +74,7 @@ def main():
             func = commands.CommandRegister.all_commands[args['<command>']]
         except KeyError:
             print('{} is not a valid command'.format(args['<command>']))
-            exit(1)
+            sys.exit(1)
         try:
             command_args = docopt(func.__doc__, argv=argv)
         except DocoptLanguageError:


### PR DESCRIPTION
exit is only intended to be used by interactive interpreter shell and
should not be used in programs. (cf https://docs.python.org/3.6/library/constants.html#constants-added-by-the-site-module)

This causes problem to build binary with pyinstaller