### PR TITLE
fix(base.py): cast into a float more than an int percentage

### DIFF
--- a/sauna/plugins/base.py
+++ b/sauna/plugins/base.py
@@ -63,9 +63,9 @@ class Plugin:
     @classmethod
     def _strip_percent_sign(cls, value):
         try:
-            return int(value)
+            return float(value)
         except ValueError:
-            return int(value.split('%')[0])
+            return float(value.split('%')[0])
 
     @classmethod
     def _strip_percent_sign_from_check_config(cls, check_config):


### PR DESCRIPTION
Hello!

I submit this pull request in order to support natively numerical number percentage in the configuration.

There is an example below:

```yml
---
...
plugins:
  - type: memory
    checks:
      - type: used_percent
        name: memory_used_percent
        warn: 89.1%
        crit: 90.9%
      - type: swap_used_percent
        name: memory_swap_used_percent
        warn: 5%
        crit: 50%
```